### PR TITLE
Updated the repository url to the new organization

### DIFF
--- a/ajax/libs/bootstrap-datepicker/package.json
+++ b/ajax/libs/bootstrap-datepicker/package.json
@@ -10,7 +10,7 @@
   ],
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/eternicode/bootstrap-datepicker.git",
+    "target": "git://github.com/uxsolutions/bootstrap-datepicker.git",
     "basePath": "dist",
     "files": [
       "**/*"
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/eternicode/bootstrap-datepicker.git"
+    "url": "https://github.com/uxsolutions/bootstrap-datepicker.git"
   },
   "license": "Apache-2.0",
   "author": "Andrew Rowls <eternicode@gmail.com>"


### PR DESCRIPTION
The repository was moved from eternicode to uxsolutions. Github does redirect the old repository url, but to cleanup this config and avoid useless redirects I've updated the repository urls
